### PR TITLE
PMM-4010 Updated travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ services:
 
 go:
   - 1.12.x
-  # TODO - 1.13.x
+  - 1.13.x
   # TODO - master
 
 matrix:
@@ -21,6 +21,12 @@ cache:
 before_cache:
   - go clean -testcache
   # - go clean -cache
+
+branches:
+   except:
+     - /^PMM\-\d{4}/
+
+go_import_path: github.com/percona/pmm-update
 
 env:
   global:


### PR DESCRIPTION
- Based on PMM-2.0 branch
- Added go_import_path
- Made it skip non-trunk PMM-XXXX branch builds, but still build pull requests.