### PR TITLE
PMM-5960 Fix supervisord.service path.

### DIFF
--- a/ansible/playbook/tasks/update.yml
+++ b/ansible/playbook/tasks/update.yml
@@ -28,19 +28,8 @@
         dest: /usr/lib/systemd/system/supervisord.service
         mode: 0644
 
-    - name: Check if old supervisord service confiuration exists
-      when: ansible_virtualization_type != "docker"
-      stat: path=/etc/systemd/system/supervisord.service checksum_algorithm=md5
-      register: is_old_supervisord
-
-    - name: Check and write in log if old supervisord service confiuration was modified.
-      when: ansible_virtualization_type != "docker" and is_old_supervisord.stat.exists and is_old_supervisord.stat.checksum != "9c618e7860d822053193faca9240ed9f"
-      fail:
-        msg: '/etc/systemd/system/supervisord.service was modified - please ensure it is compatible with updates in /etc/systemd/system/supervisord.service'
-      ignore_errors: yes
-
     - name: Remove old supervisord service confiuration
-      when: ansible_virtualization_type != "docker" and is_old_supervisord.stat.exists and is_old_supervisord.stat.checksum == "9c618e7860d822053193faca9240ed9f"
+      when: ansible_virtualization_type != "docker"
       file:
         path: /etc/systemd/system/supervisord.service
         state: absent

--- a/ansible/playbook/tasks/update.yml
+++ b/ansible/playbook/tasks/update.yml
@@ -25,7 +25,7 @@
       when: ansible_virtualization_type != "docker"
       copy:
         src: supervisord.service
-        dest: /etc/systemd/system/
+        dest: /usr/lib/systemd/system/supervisord.service
         mode: 0644
 
     # See https://github.com/Supervisor/supervisor/issues/1264 for explanation

--- a/ansible/playbook/tasks/update.yml
+++ b/ansible/playbook/tasks/update.yml
@@ -28,6 +28,23 @@
         dest: /usr/lib/systemd/system/supervisord.service
         mode: 0644
 
+    - name: Check if old supervisord service confiuration exists
+      when: ansible_virtualization_type != "docker"
+      stat: path=/etc/systemd/system/supervisord.service checksum_algorithm=md5
+      register: is_old_supervisord
+
+    - name: Check and write in log if old supervisord service confiuration was modified.
+      when: ansible_virtualization_type != "docker" and is_old_supervisord.stat.exists and is_old_supervisord.stat.checksum != "9c618e7860d822053193faca9240ed9f"
+      fail:
+        msg: '/etc/systemd/system/supervisord.service was modified - please ensure it is compatible with updates in /etc/systemd/system/supervisord.service'
+      ignore_errors: yes
+
+    - name: Remove old supervisord service confiuration
+      when: ansible_virtualization_type != "docker" and is_old_supervisord.stat.exists and is_old_supervisord.stat.checksum == "9c618e7860d822053193faca9240ed9f"
+      file:
+        path: /etc/systemd/system/supervisord.service
+        state: absent
+
     # See https://github.com/Supervisor/supervisor/issues/1264 for explanation
     # why we do reread + stop/remove/add instead of using supervisorctl Ansible module.
 


### PR DESCRIPTION
https://jira.percona.com/browse/PMM-5960

**UPDATE:** We do not need to additionally check as we do not support any changes in configuration made by a user.

1. During PMM update from 2.5.0 to 2.6.1
   - was fixed start of supervisord as not forked.
   - new supervisord.service with the fix was placed in  `/etc/systemd/system/`
   - but the old broken left in `/usr/lib/systemd/system/`

~~2. supervisord is installed using `pip`- so to update it the user should be much more specific then `using yum update`~~

3. There are two places pmm build process operate with `supervisord.service`:
    - https://github.com/Percona-Lab/percona-images/blob/master/ansible/roles/supervisord-init/tasks/main.yml#L88
    - https://github.com/percona/pmm-update/blob/PMM-2.0/ansible/playbook/tasks/update.yml#L28

4. According to the discussion  `/usr/lib/systemd/system/` is preferable in our case.

5. This fix unify the approach to use only one supervisord.service located in `/usr/lib/systemd/system/`
   - place fixed `supervisord.service` in `/usr/lib/systemd/system/`;
   - remove `supervisord.service` from `/etc/systemd/system/`;
   ~~- Notify/Log during update if `/etc/systemd/system/supervisord.service` was modified.~~


