### PR TITLE
PMM-6639: Incomplete container detection in update

### DIFF
--- a/ansible/playbook/tasks/update.yml
+++ b/ansible/playbook/tasks/update.yml
@@ -20,18 +20,22 @@
       - dbaas-controller
       - dbaas-tools
       - pmm2-client
+  pre_tasks:
+    - name: detect containers
+      set_fact:
+        is_container: '{{ lookup("file", "/srv/pmm-distribution") == "docker" }}'
 
   tasks:
     # Replace forking type with simple. New config will be applied after next reboot.
     - name: Configure systemd
-      when: ansible_virtualization_type != "docker"
+      when: not is_container
       copy:
         src: supervisord.service
         dest: /usr/lib/systemd/system/supervisord.service
         mode: 0644
 
     - name: Remove old supervisord service confiuration
-      when: ansible_virtualization_type != "docker"
+      when: not is_container
       file:
         path: /etc/systemd/system/supervisord.service
         state: absent
@@ -81,7 +85,7 @@
 
     # https://jira.percona.com/browse/PMM-5271
     - name: Check volume size
-      when: ansible_virtualization_type != "docker"
+      when: not is_container
       replace:
         dest: /var/lib/cloud/scripts/per-boot/resize-xfs
         regexp: 'set -o errexit'

--- a/ansible/playbook/tasks/update.yml
+++ b/ansible/playbook/tasks/update.yml
@@ -21,9 +21,22 @@
       - dbaas-tools
       - pmm2-client
   pre_tasks:
+    - name: detect /srv/pmm-distribution
+      stat:
+        path: /srv/pmm-distribution
+      no_log: yes
+      register: srv_pmm_distribution
+
     - name: detect containers
       set_fact:
         is_container: '{{ lookup("file", "/srv/pmm-distribution") == "docker" }}'
+      no_log: yes
+      when: srv_pmm_distribution.stat.exists
+
+    - name: force container
+      set_fact:
+        is_container: True
+      when: is_container is undefined
 
   tasks:
     # Replace forking type with simple. New config will be applied after next reboot.


### PR DESCRIPTION
The playbook relies on the presence of `ansible_virtualization_type == "docker"`
to filter tasks that should not run in containers.

This is invalid when running a container that is not running in Docker and
so a pre-task is now added to validate against the content of:
- `/srv/pmm-distribution`

When this evaluates to "docker" then the host will be marked as being
a container with `is_container: True`