### PR TITLE
PMM-8169: Improve Release date capture for PMM server

### DIFF
--- a/.devcontainer/install-dev-tools.sh
+++ b/.devcontainer/install-dev-tools.sh
@@ -22,7 +22,7 @@ yum install -y yum rpm
 yum reinstall -y yum rpm
 
 yum install -y gcc git make pkgconfig glibc-static \
-    ansible-lint \
+    ansible-lint ansible \
     mc tmux psmisc lsof which iproute \
     bash-completion bash-completion-extras \
     man man-pages

--- a/.devcontainer/install-dev-tools.sh
+++ b/.devcontainer/install-dev-tools.sh
@@ -13,8 +13,8 @@ curl -sS https://dl.google.com/go/go1.15.6.linux-amd64.tar.gz -o /tmp/golang.tar
 # to install man pages
 sed -i '/nodocs/d' /etc/yum.conf
 
-# enable laboratory repository with latest development packages
-sed -i'' -e 's^/release/^/laboratory/^' /etc/yum.repos.d/pmm2-server.repo
+# enable experimental repository with latest development packages
+sed -i'' -e 's^/release/^/experimental/^' /etc/yum.repos.d/pmm2-server.repo
 percona-release enable original testing
 
 # reinstall with man pages

--- a/pkg/yum/info.go
+++ b/pkg/yum/info.go
@@ -25,7 +25,7 @@ import (
 )
 
 // parseInfo parses `yum info` stdout for a single version of a single package.
-// also used to parse `yum repoinfo`
+// also used to parse `yum repoinfo`.
 func parseInfo(lines []string, firstKey string) (map[string]string, error) {
 	res := make(map[string]string)
 	var prevKey string

--- a/pkg/yum/info.go
+++ b/pkg/yum/info.go
@@ -25,10 +25,11 @@ import (
 )
 
 // parseInfo parses `yum info` stdout for a single version of a single package.
-func parseInfo(lines []string) (map[string]string, error) {
+// also used to parse `yum repoinfo`
+func parseInfo(lines []string, firstKey string) (map[string]string, error) {
 	res := make(map[string]string)
 	var prevKey string
-	var nameFound bool
+	var keyFound bool
 	for _, line := range lines {
 		// separate progress output from data
 		line = strings.TrimSpace(line)
@@ -40,14 +41,14 @@ func parseInfo(lines []string) (map[string]string, error) {
 			continue
 		}
 		key := strings.TrimSpace(parts[0])
-		if key == "Name" {
+		if key == firstKey {
 			// sanity check that we do not try to parse multiple packages
-			if nameFound {
+			if keyFound {
 				return res, errors.New("second `Name` encountered")
 			}
-			nameFound = true
+			keyFound = true
 		}
-		if !nameFound {
+		if !keyFound {
 			continue
 		}
 

--- a/pkg/yum/info_test.go
+++ b/pkg/yum/info_test.go
@@ -76,7 +76,7 @@ func TestParseInfo(t *testing.T) {
 				"Grafana, etc.) and exposes API for that.  Those APIs are used by pmm-admin tool. " +
 				"See the PMM docs for more information.",
 		}
-		actual, err := parseInfo(stdout)
+		actual, err := parseInfo(stdout, "Name")
 		require.NoError(t, err)
 		assert.Equal(t, expected, actual)
 		buildtime, err := parseInfoTime(actual["Buildtime"])
@@ -137,7 +137,7 @@ func TestParseInfo(t *testing.T) {
 			"License":     "AGPLv3",
 			"Description": "Tool for updating packages and OS configuration for PMM Server",
 		}
-		actual, err := parseInfo(stdout)
+		actual, err := parseInfo(stdout, "Name")
 		require.NoError(t, err)
 		assert.Equal(t, expected, actual)
 		buildtime, err := parseInfoTime(actual["Buildtime"])
@@ -209,7 +209,7 @@ func TestParseInfo(t *testing.T) {
 			"License":     "AGPLv3",
 			"Description": "Tool for updating packages and OS configuration for PMM Server",
 		}
-		actual, err := parseInfo(stdout)
+		actual, err := parseInfo(stdout, "Name")
 		assert.EqualError(t, err, "second `Name` encountered")
 		assert.Equal(t, expected, actual)
 		buildtime, err := parseInfoTime(actual["Buildtime"])
@@ -254,7 +254,7 @@ func TestParseInfo(t *testing.T) {
 			"License":     "AGPLv3",
 			"Description": "Tool for updating packages and OS configuration for PMM Server",
 		}
-		actual, err := parseInfo(stdout)
+		actual, err := parseInfo(stdout, "Name")
 		require.NoError(t, err)
 		assert.Equal(t, expected, actual)
 		buildtime, err := parseInfoTime(actual["Buildtime"])
@@ -287,8 +287,54 @@ func TestParseInfo(t *testing.T) {
 			up:condense time: 0.000
 			updates time: 0.469
 		`, "\n")
-		actual, err := parseInfo(stdout)
+		actual, err := parseInfo(stdout, "Name")
 		require.NoError(t, err)
 		assert.Empty(t, actual)
+	})
+
+	t.Run("RepoInfo", func(t *testing.T) {
+		// yum repoinfo pmm2-server
+		stdout := strings.Split(`
+			Loaded plugins: changelog, fastestmirror, ovl
+			Loading mirror speeds from cached hostfile
+			* base: centos.schlundtech.de
+			* epel: mirror.netcologne.de
+			* extras: centos.mirror.iphh.net
+			* updates: mirror.netcologne.de
+			Repo-id      : pmm2-server
+			Repo-name    : PMM Server YUM repository - x86_64
+			Repo-status  : enabled
+			Repo-revision: 1622561436
+			Repo-updated : Tue Jun  1 15:30:45 2021
+			Repo-pkgs    : 237
+			Repo-size    : 2.4 G
+			Repo-baseurl : https://repo.percona.com/pmm2-components/yum/release/7/RPMS/x86_64/
+			Repo-expire  : 21600 second(s) (last: Thu Jun 10 16:08:12 2021)
+			Filter     : read-only:present
+			Repo-filename: /etc/yum.repos.d/pmm2-server.repo
+			
+			repolist: 237
+			…
+		`, "\n")
+		expected := map[string]string{
+			"Repo-id":          "pmm2-server",
+			"Repo-name":        "PMM Server YUM repository - x86_64",
+			"Repo-status":      "enabled",
+			"Repo-revision":    "1622561436",
+			"Repo-updated":     "Tue Jun  1 15:30:45 2021",
+			"Repo-pkgs":        "237",
+			"Repo-size":        "2.4 G",
+			"Repo-baseurl":     "https://repo.percona.com/pmm2-components/yum/release/7/RPMS/x86_64/",
+			"Repo-expire":      "21600 second(s) (last: Thu Jun 10 16:08:12 2021)",
+			"Filter":           "read-only:present",
+			"Repo-filename":    "/etc/yum.repos.d/pmm2-server.repo",
+			"repolist":         "237",
+		}
+		actual, err := parseInfo(stdout, "Repo-id")
+		require.NoError(t, err)
+		assert.Equal(t, expected, actual)
+		releasetime, err := parseInfoTime(actual["Repo-updated"])
+		require.NoError(t, err)
+		assert.Equal(t, time.Date(2021, 6, 1, 15, 30, 45, 0, time.UTC), releasetime)
 	})
 }

--- a/pkg/yum/info_test.go
+++ b/pkg/yum/info_test.go
@@ -293,7 +293,7 @@ func TestParseInfo(t *testing.T) {
 	})
 
 	t.Run("RepoInfo", func(t *testing.T) {
-		// yum repoinfo pmm2-server
+		// yum repoinfo pmm2-server.
 		stdout := strings.Split(`
 			Loaded plugins: changelog, fastestmirror, ovl
 			Loading mirror speeds from cached hostfile

--- a/pkg/yum/info_test.go
+++ b/pkg/yum/info_test.go
@@ -317,18 +317,18 @@ func TestParseInfo(t *testing.T) {
 			…
 		`, "\n")
 		expected := map[string]string{
-			"Repo-id":          "pmm2-server",
-			"Repo-name":        "PMM Server YUM repository - x86_64",
-			"Repo-status":      "enabled",
-			"Repo-revision":    "1622561436",
-			"Repo-updated":     "Tue Jun  1 15:30:45 2021",
-			"Repo-pkgs":        "237",
-			"Repo-size":        "2.4 G",
-			"Repo-baseurl":     "https://repo.percona.com/pmm2-components/yum/release/7/RPMS/x86_64/",
-			"Repo-expire":      "21600 second(s) (last: Thu Jun 10 16:08:12 2021)",
-			"Filter":           "read-only:present",
-			"Repo-filename":    "/etc/yum.repos.d/pmm2-server.repo",
-			"repolist":         "237",
+			"Repo-id":       "pmm2-server",
+			"Repo-name":     "PMM Server YUM repository - x86_64",
+			"Repo-status":   "enabled",
+			"Repo-revision": "1622561436",
+			"Repo-updated":  "Tue Jun  1 15:30:45 2021",
+			"Repo-pkgs":     "237",
+			"Repo-size":     "2.4 G",
+			"Repo-baseurl":  "https://repo.percona.com/pmm2-components/yum/release/7/RPMS/x86_64/",
+			"Repo-expire":   "21600 second(s) (last: Thu Jun 10 16:08:12 2021)",
+			"Filter":        "read-only:present",
+			"Repo-filename": "/etc/yum.repos.d/pmm2-server.repo",
+			"repolist":      "237",
 		}
 		actual, err := parseInfo(stdout, "Repo-id")
 		require.NoError(t, err)

--- a/pkg/yum/yum.go
+++ b/pkg/yum/yum.go
@@ -43,7 +43,7 @@ func Installed(ctx context.Context, name string) (*version.UpdateInstalledResult
 		return nil, errors.Wrapf(err, "%#q failed", cmdLine)
 	}
 
-	info, err := parseInfo(stdout)
+	info, err := parseInfo(stdout, "Name")
 	if err != nil {
 		return nil, err
 	}
@@ -59,6 +59,26 @@ func Installed(ctx context.Context, name string) (*version.UpdateInstalledResult
 	return &version.UpdateInstalledResult{
 		Installed: res,
 	}, nil
+}
+
+// getReleaseTime returns date and time when repo was updated (packages published or repo got rebuilt)
+func getReleaseTime(ctx context.Context, repo string) (string, error) {
+	cmdLine := "yum repoinfo " + repo
+	stdout, _, err := run.Run(ctx, yumInfoCancelTimeout, cmdLine, nil)
+	if err != nil {
+		return "", errors.Wrapf(err, "%#q failed", cmdLine)
+	}
+
+	info, err := parseInfo(stdout, "Repo-id")
+	if err != nil {
+		return "", err
+	}
+
+	if time, ok := info["Repo-updated"]; ok {
+		return time, nil
+	}
+
+	return "", errors.New("Repo-updated field is not found in repoinfo")
 }
 
 // Check returns up-to-date versions information for a package with given name.
@@ -84,7 +104,7 @@ func Check(ctx context.Context, name string) (*version.UpdateCheckResult, error)
 		return nil, errors.Wrapf(err, "%#q failed", cmdLine)
 	}
 
-	info, err := parseInfo(stdout)
+	info, err := parseInfo(stdout, "Name")
 	if err != nil {
 		return nil, err
 	}
@@ -93,9 +113,15 @@ func Check(ctx context.Context, name string) (*version.UpdateCheckResult, error)
 		FullVersion: fullVersion(info),
 		Repo:        info["Repo"],
 	}
-	buildTime, err := parseInfoTime(info["Buildtime"])
+	
+	//replace Buildtime with repo release time to show time of release
+	repoUpdated, err := getReleaseTime(ctx, info["Repo"])
+	if err != nil {
+		return nil, err
+	}
+	releaseTime, err := parseInfoTime(repoUpdated)
 	if err == nil {
-		res.Latest.BuildTime = &buildTime
+		res.Latest.BuildTime = &releaseTime
 	}
 
 	cmdLine = "yum update " + name + " --changelog --cacheonly --assumeno"

--- a/pkg/yum/yum.go
+++ b/pkg/yum/yum.go
@@ -114,7 +114,7 @@ func Check(ctx context.Context, name string) (*version.UpdateCheckResult, error)
 		Repo:        info["Repo"],
 	}
 
-	// replace Buildtime with repo release time to show time of release
+	// replace Buildtime with repo release time to show time of release.
 	repoUpdated, err := getReleaseTime(ctx, info["Repo"])
 	if err != nil {
 		return nil, err

--- a/pkg/yum/yum.go
+++ b/pkg/yum/yum.go
@@ -113,7 +113,7 @@ func Check(ctx context.Context, name string) (*version.UpdateCheckResult, error)
 		FullVersion: fullVersion(info),
 		Repo:        info["Repo"],
 	}
-	
+
 	//replace Buildtime with repo release time to show time of release
 	repoUpdated, err := getReleaseTime(ctx, info["Repo"])
 	if err != nil {

--- a/pkg/yum/yum.go
+++ b/pkg/yum/yum.go
@@ -61,7 +61,7 @@ func Installed(ctx context.Context, name string) (*version.UpdateInstalledResult
 	}, nil
 }
 
-// getReleaseTime returns date and time when repo was updated (packages published or repo got rebuilt)
+// getReleaseTime returns date and time when repo was updated (packages published or repo got rebuilt).
 func getReleaseTime(ctx context.Context, repo string) (string, error) {
 	cmdLine := "yum repoinfo " + repo
 	stdout, _, err := run.Run(ctx, yumInfoCancelTimeout, cmdLine, nil)
@@ -114,7 +114,7 @@ func Check(ctx context.Context, name string) (*version.UpdateCheckResult, error)
 		Repo:        info["Repo"],
 	}
 
-	//replace Buildtime with repo release time to show time of release
+	// replace Buildtime with repo release time to show time of release
 	repoUpdated, err := getReleaseTime(ctx, info["Repo"])
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
Replace BuildDate with the repoinfo instead of package info, so package
don't need to be rebuild on the release date. repoinfo date updates on
release date.