### PR TITLE
Use pidof to check if dbaas-controller is running

### DIFF
--- a/ansible/playbook/tasks/update.yml
+++ b/ansible/playbook/tasks/update.yml
@@ -223,6 +223,7 @@
     - name: Restart dbaas-controller
       command: supervisorctl {{ item }} dbaas-controller
       changed_when: True
+      debug: {{ dbaas_controller_pid_check }}
       when: dbaas_controller_pid_check.stdout != ""
       loop:
         - "stop"

--- a/ansible/playbook/tasks/update.yml
+++ b/ansible/playbook/tasks/update.yml
@@ -222,7 +222,7 @@
     - name: Restart dbaas-controller
       command: supervisorctl {{ item }} dbaas-controller
       changed_when: True
-      when: "'stdout' in dbaas_controller_pid_check.results"
+      when: "'stdout' in dbaas_controller_pid_check"
       loop:
         - "stop"
         - "remove"

--- a/ansible/playbook/tasks/update.yml
+++ b/ansible/playbook/tasks/update.yml
@@ -29,9 +29,9 @@
       no_log: yes
       when: srv_pmm_distribution.stat.exists
 
-    - name: set dbaas toggle
-      set_fact:
-        is_dbaas_on: "{{ lookup('env', 'PERCONA_TEST_DBAAS') == '1' }}"
+    - name: set dbaas-controller pid
+      shell: pidof dbaas-controller
+      register: dbaas_controller_pid_check
       no_log: yes
 
     - name: force container
@@ -222,7 +222,7 @@
     - name: Restart dbaas-controller
       command: supervisorctl {{ item }} dbaas-controller
       changed_when: True
-      when: is_dbaas_on
+      when: dbaas_controller_pid_check.stdout != ''
       loop:
         - "stop"
         - "remove"

--- a/ansible/playbook/tasks/update.yml
+++ b/ansible/playbook/tasks/update.yml
@@ -30,7 +30,7 @@
       when: srv_pmm_distribution.stat.exists
 
     - name: set dbaas-controller pid
-      shell: pidof dbaas-controller
+      shell: pgrep dbaas-controller
       register: dbaas_controller_pid_check
       #no_log: yes
 

--- a/ansible/playbook/tasks/update.yml
+++ b/ansible/playbook/tasks/update.yml
@@ -222,7 +222,7 @@
     - name: Restart dbaas-controller
       command: supervisorctl {{ item }} dbaas-controller
       changed_when: True
-      when: "stdout" in dbaas_controller_pid_check.results != ''
+      when: '"stdout" in dbaas_controller_pid_check.results' != ''
       loop:
         - "stop"
         - "remove"

--- a/ansible/playbook/tasks/update.yml
+++ b/ansible/playbook/tasks/update.yml
@@ -32,7 +32,7 @@
     - name: set dbaas-controller pid
       shell: pgrep dbaas-controller
       register: dbaas_controller_pid_check
-      failed_when: '"stderr" in dbaas_controller_pid_check'
+      failed_when: dbaas_controller_pid_check.stderr != ""
       #no_log: yes
 
     - name: force container
@@ -223,7 +223,7 @@
     - name: Restart dbaas-controller
       command: supervisorctl {{ item }} dbaas-controller
       changed_when: True
-      when: "'stdout' in dbaas_controller_pid_check"
+      when: dbaas_controller_pid_check.stdout != ""
       loop:
         - "stop"
         - "remove"

--- a/ansible/playbook/tasks/update.yml
+++ b/ansible/playbook/tasks/update.yml
@@ -222,7 +222,7 @@
     - name: Restart dbaas-controller
       command: supervisorctl {{ item }} dbaas-controller
       changed_when: True
-      when: '"stdout" in dbaas_controller_pid_check.results' != ''
+      when: "'stdout' in dbaas_controller_pid_check.results"
       loop:
         - "stop"
         - "remove"

--- a/ansible/playbook/tasks/update.yml
+++ b/ansible/playbook/tasks/update.yml
@@ -222,7 +222,7 @@
     - name: Restart dbaas-controller
       command: supervisorctl {{ item }} dbaas-controller
       changed_when: True
-      when: dbaas_controller_pid_check.stdout != ''
+      when: "stdout" in dbaas_controller_pid_check.results != ''
       loop:
         - "stop"
         - "remove"

--- a/ansible/playbook/tasks/update.yml
+++ b/ansible/playbook/tasks/update.yml
@@ -32,6 +32,7 @@
     - name: set dbaas-controller pid
       shell: pgrep dbaas-controller
       register: dbaas_controller_pid_check
+      failed_when: '"stderr" in dbaas_controller_pid_check'
       #no_log: yes
 
     - name: force container

--- a/ansible/playbook/tasks/update.yml
+++ b/ansible/playbook/tasks/update.yml
@@ -32,7 +32,7 @@
     - name: set dbaas-controller pid
       shell: pidof dbaas-controller
       register: dbaas_controller_pid_check
-      no_log: yes
+      #no_log: yes
 
     - name: force container
       set_fact:


### PR DESCRIPTION
If pid is not empty, it means DBaaS is enabled.

We can't rely on env vars, because their name can change and DBaaS can be enabled using UI anyway.