### PR TITLE
PMM-7 Remove useless clickhouse binary

### DIFF
--- a/ansible/playbook/tasks/roles/clickhouse/tasks/main.yml
+++ b/ansible/playbook/tasks/roles/clickhouse/tasks/main.yml
@@ -72,6 +72,11 @@
     - cap_sys_nice
     - cap_net_admin
 
+- name: Remove clickhouse-odbc-bridge binary
+  file:
+    path: "/usr/bin/clickhouse-odbc-bridge"
+    state: absent
+
 - name: Start clickhouse
   command: supervisorctl add clickhouse
   changed_when: True


### PR DESCRIPTION
We don't use `/usr/bin/clickhouse-odbc-bridge` binary and file size is ~100MB. It makes sense to delete it.