### PR TITLE
PMM-9772 remove yum cache with rm

### DIFF
--- a/ansible/playbook/tasks/update.yml
+++ b/ansible/playbook/tasks/update.yml
@@ -295,6 +295,7 @@
       debug: var=maintail_result.stdout_lines
 
     - name: Cleanup yum cache
-      command: yum clean all
-      register: yum_clean_result
-      changed_when: "'Cleaning repos' in yum_clean_result.stdout"
+      command: rm -rf /var/cache/yum
+      changed_when: True
+
+ 

--- a/ansible/playbook/tasks/update.yml
+++ b/ansible/playbook/tasks/update.yml
@@ -294,6 +294,7 @@
     - name: Check supervisord log
       debug: var=maintail_result.stdout_lines
 
-    - name: Cleanup yum cache
-      command: rm -rf /var/cache/yum
-      changed_when: True
+    - name: Delete content & directory
+      file:
+        state: absent
+        path: /var/cache/yum

--- a/ansible/playbook/tasks/update.yml
+++ b/ansible/playbook/tasks/update.yml
@@ -297,5 +297,3 @@
     - name: Cleanup yum cache
       command: rm -rf /var/cache/yum
       changed_when: True
-
- 


### PR DESCRIPTION
`yum clean all` can't remove cache if it's corrupted. We also will have less chance to have a broken cache if we'll just remove it after upgrade