### PR TITLE
Fix proxy path for /prometheus/rules

### DIFF
--- a/ansible/playbook/tasks/roles/nginx/files/conf.d/pmm.conf
+++ b/ansible/playbook/tasks/roles/nginx/files/conf.d/pmm.conf
@@ -129,7 +129,7 @@
 
     # VMAlert
     location /prometheus/rules {
-      proxy_pass http://127.0.0.1:8880/api/v1/groups;
+      proxy_pass http://127.0.0.1:8880/api/v1/rules;
       proxy_read_timeout 600;
     }
     location /prometheus/alerts {


### PR DESCRIPTION
Because of breaking changes in Victoria Metrics in version [1.75.0](https://docs.victoriametrics.com/CHANGELOG.html#v1750) we have to update our nginx rules

PMM-0

Build: SUBMODULES-0

- [ ] Links to other linked pull requests (optional).
