### PR TITLE
PMM-10272 run supervisord with root

### DIFF
--- a/ansible/playbook/tasks/roles/postgres/tasks/main.yml
+++ b/ansible/playbook/tasks/roles/postgres/tasks/main.yml
@@ -118,8 +118,8 @@
       postgresql_user:
         db: pmm-managed
         name: pmm-managed
-        password: 'md5da757ec3e22c6d86a2bb8e70307fa937'
-        priv: 'ALL'
+        password: "md5da757ec3e22c6d86a2bb8e70307fa937"
+        priv: "ALL"
         expires: infinity
         state: present
       when: is_upgrade.stat.exists
@@ -157,11 +157,15 @@
 
     - name: Reread supervisord configuration
       command: supervisorctl reread
+      become: yes
+      become_user: root
       register: supervisor_result
       changed_when: "'No config updates to processes' not in supervisor_result.stdout"
 
     - name: Restart Postgres
       command: supervisorctl {{ item }} postgresql
+      become: yes
+      become_user: root
       changed_when: True
       loop:
         - stop
@@ -175,4 +179,3 @@
         state: started
       when: is_upgrade.stat.exists
   when: not is_postgres_14.stat.exists
-

--- a/ansible/playbook/tasks/roles/postgres/tasks/main.yml
+++ b/ansible/playbook/tasks/roles/postgres/tasks/main.yml
@@ -161,7 +161,7 @@
       become_user: root
       become_method: su
       register: supervisor_result
-      changed_when: "'No config updates to processes' not in supervisor_result.stdout"
+      # changed_when: "'No config updates to processes' not in supervisor_result.stdout"
       when: is_upgrade.stat.exists
 
     - name: Restart Postgres

--- a/ansible/playbook/tasks/roles/postgres/tasks/main.yml
+++ b/ansible/playbook/tasks/roles/postgres/tasks/main.yml
@@ -157,18 +157,10 @@
 
     - name: Reread supervisord configuration
       command: supervisorctl reread
-      become: yes
-      become_user: root
-      become_method: su
-      register: supervisor_result
-      # changed_when: "'No config updates to processes' not in supervisor_result.stdout"
       when: is_upgrade.stat.exists
 
     - name: Restart Postgres
       command: supervisorctl {{ item }} postgresql
-      become: yes
-      become_user: root
-      become_method: su
       changed_when: True
       loop:
         - stop

--- a/ansible/playbook/tasks/roles/postgres/tasks/main.yml
+++ b/ansible/playbook/tasks/roles/postgres/tasks/main.yml
@@ -162,6 +162,7 @@
       become_method: su
       register: supervisor_result
       changed_when: "'No config updates to processes' not in supervisor_result.stdout"
+      when: is_upgrade.stat.exists
 
     - name: Restart Postgres
       command: supervisorctl {{ item }} postgresql

--- a/ansible/playbook/tasks/roles/postgres/tasks/main.yml
+++ b/ansible/playbook/tasks/roles/postgres/tasks/main.yml
@@ -159,6 +159,7 @@
       command: supervisorctl reread
       become: yes
       become_user: root
+      become_method: su
       register: supervisor_result
       changed_when: "'No config updates to processes' not in supervisor_result.stdout"
 
@@ -166,6 +167,7 @@
       command: supervisorctl {{ item }} postgresql
       become: yes
       become_user: root
+      become_method: su
       changed_when: True
       loop:
         - stop

--- a/ansible/playbook/tasks/update.yml
+++ b/ansible/playbook/tasks/update.yml
@@ -295,7 +295,7 @@
     - name: Check other services
       debug: var=update_result.stdout_lines
 
-    # SIGUSR2 is sent to supervisord by pmm-managed right before the update to for logging to work correctly.
+    # SIGUSR2 is sent to supervisord by pmm-managed right before the update for logging to work correctly.
     # We use that fact to show what was restarted during the update.
     - name: Get supervisord log
       shell: supervisorctl maintail -100000 | tac | awk '!flag; /received SIGUSR2/{flag = 1};' | tac


### PR DESCRIPTION
PMM-7

This fixes a broken pipeline where supervisor is trying to run the `reread` command while supervisord is not running.
