### PR TITLE
PMM-11126 PMM server cannot be updated to 2.32.0

### DIFF
--- a/ansible/playbook/tasks/update.yml
+++ b/ansible/playbook/tasks/update.yml
@@ -182,7 +182,7 @@
         state: latest
         security: yes
         exclude:
-          - 'nginx*'
+          - nginx*
 
     - name: Updating vulnerable packages
       yum:

--- a/ansible/playbook/tasks/update.yml
+++ b/ansible/playbook/tasks/update.yml
@@ -182,7 +182,7 @@
         state: latest
         security: yes
         exclude:
-          - nginx
+          - 'nginx*'
 
     - name: Updating vulnerable packages
       yum:


### PR DESCRIPTION
The nginx package is excluded from the updated, but related packages may have an update available and so they need to be excluded too.

[PMM-11126](https://jira.percona.com/browse/PMM-11126)

Build: [SUBMODULES-2910](https://github.com/Percona-Lab/pmm-submodules/pull/2910)

